### PR TITLE
Fix p0 on ARM64

### DIFF
--- a/grading/submissions/astudent/p0/main.c
+++ b/grading/submissions/astudent/p0/main.c
@@ -16,7 +16,7 @@ int main (int argc, char **argv)
     bool cat = false;
     char *cat_fn = NULL;
 
-    char c;
+    int c;
     while ((c = getopt(argc, argv, "gf:c:")) != -1) {
         switch (c) {
 

--- a/grading/submissions/bstudent/p0/main.c
+++ b/grading/submissions/bstudent/p0/main.c
@@ -16,7 +16,7 @@ int main (int argc, char **argv)
     bool cat = false;
     char *cat_fn = NULL;
 
-    char c;
+    int c;
     while ((c = getopt(argc, argv, "gf:c:")) != -1) {
         switch (c) {
 

--- a/ref/p0-intro/main.c
+++ b/ref/p0-intro/main.c
@@ -18,7 +18,7 @@ int main (int argc, char **argv)
     bool cat = false;
     char *cat_fn = NULL;
 
-    char c;
+    int c;
     while ((c = getopt(argc, argv, "gf:c:")) != -1) {
         switch (c) {
 


### PR DESCRIPTION
There seems to be an issue with comparing a char and an int with the
value -1. Using an int to store the parameter of getopt fixes the
problems with the switch statement always hitting the default case.

Resolves #6.