### PR TITLE
Allow for hidden unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,13 @@ details about how the tests work and for instructions on adding new tests.
 Unit tests are intended to test individual routines (and their dependencies),
 and they are written in C using the [Check](https://libcheck.github.io/check/)
 framework. Often, the code for these tests tends to resemble the solution, so it
-is desirable to distribute these tests without their source. Thus, there are two
-main unit testing files: `public.c` and `private.c`. The former is distributed
-as-is so that the students can see how the test is written, and the latter is
-distributed as a stripped object file so that students can run the tests and see
-the results but they do not have access to the source code.
+is desirable to distribute these tests without their source. Thus, there are
+three main unit testing files: `public.c`, `private.c`, and `hidden.c`. The
+first is distributed as-is so that the students can see how the test is
+written, the second is distributed as a stripped object file so that students
+can run the tests and see the results but they do not have access to the source
+code, and the third is not distributed at all, allowing for tests students
+neither have access to nor know about.
 
 Tests are delimited using the `START_TEST` and `END_TEST` macros provided by
 Check. Testing expressions are written using Check assertion routines
@@ -120,7 +122,7 @@ top.
 To add a new integration test: 1) put any necessary input (not all integration
 tests require an input file; e.g., if all parameters are provided on the command
 line) in the `inputs` folder, 2) put the required output in a text file in the
-`expected' folder, and 3) add a corresponding line to `itests.include`.
+`expected` folder, and 3) add a corresponding line to `itests.include`.
 
 Note that there is no "code" for integration tests and thus there are no
 "private" integration tests. If you wish to have integration tests that you do

--- a/dist/rebuild-p0.sh
+++ b/dist/rebuild-p0.sh
@@ -38,8 +38,9 @@ cleanup "p0-intro.h"
 cleanup "p0-intro.c"
 
 # testsuite
+cleanup "tests/testsuite.c"
+
 make -C $REF/tests
-cp -H $REF/tests/testsuite.c       $ROOT/tests/
 cp -H $REF/tests/public.c          $ROOT/tests/
 cp -H $REF/tests/integration.sh    $ROOT/tests/
 cp -H $REF/tests/inputs/*          $ROOT/tests/inputs/

--- a/dist/rebuild-pT.sh
+++ b/dist/rebuild-pT.sh
@@ -38,8 +38,9 @@ cleanup "pT-blank.h"
 cleanup "pT-blank.c"
 
 # testsuite
+cleanup "tests/testsuite.c"
+
 make -C $REF/tests
-cp -H $REF/tests/testsuite.c       $ROOT/tests/
 cp -H $REF/tests/public.c          $ROOT/tests/
 cp -H $REF/tests/integration.sh    $ROOT/tests/
 cp -H $REF/tests/inputs/*          $ROOT/tests/inputs/

--- a/ref/p0-intro/tests/Makefile
+++ b/ref/p0-intro/tests/Makefile
@@ -24,7 +24,7 @@
 
 EXE=../intro
 TEST=testsuite
-MODS=public.o private.o
+MODS=public.o private.o hidden.o
 #MODS=public.o
 OBJS=../p0-intro.o
 #OBJS=../p0-intro.o private.o

--- a/ref/p0-intro/tests/hidden.c
+++ b/ref/p0-intro/tests/hidden.c
@@ -1,0 +1,30 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <check.h>
+
+#include "../p0-intro.h"
+
+/* negative integer addition */
+START_TEST (A_addabs_both_negative_ints)
+{
+    ck_assert_int_eq (add_abs(-2,-4), 6);
+}
+END_TEST
+
+START_TEST (A_sumarray_single_int) 
+{
+    int num = 5;
+    ck_assert_int_eq (sum_array(&num, 1), 5);
+}
+END_TEST
+
+void hidden_tests (Suite *s)
+{
+    TCase *tc_hidden = tcase_create ("Hidden");
+    tcase_add_test (tc_hidden, A_addabs_both_negative_ints);
+    tcase_add_test (tc_hidden, A_sumarray_single_int);
+    suite_add_tcase (s, tc_hidden);
+}

--- a/ref/pT-blank/tests/Makefile
+++ b/ref/pT-blank/tests/Makefile
@@ -24,7 +24,7 @@
 
 EXE=../blank
 TEST=testsuite
-MODS=public.o private.o
+MODS=public.o private.o hidden.o
 #MODS=public.o
 OBJS=../pT-blank.o
 #OBJS=../pT-blank.o private.o

--- a/ref/pT-blank/tests/hidden.c
+++ b/ref/pT-blank/tests/hidden.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <check.h>
+
+#include "../pT-blank.h"
+
+/* negative integer addition */
+START_TEST (B_add_both_negative)
+{
+    ck_assert_int_eq (add(-2,-4), -6);
+}
+END_TEST
+
+void hidden_tests (Suite *s)
+{
+    TCase *tc_hidden = tcase_create ("Hidden");
+    tcase_add_test (tc_hidden, B_add_both_negative);
+    suite_add_tcase (s, tc_hidden);
+}
+

--- a/ref/pT-blank/tests/testsuite.c
+++ b/ref/pT-blank/tests/testsuite.c
@@ -9,12 +9,22 @@
 
 extern void public_tests (Suite *s);
 extern void private_tests (Suite *s);
+// BEGIN_SOLUTION
+
+extern void hidden_tests (Suite *s);
+
+// END_SOLUTION
 
 Suite * test_suite (void)
 {
     Suite *s = suite_create ("Default");
     public_tests (s);
     private_tests (s);
+    // BEGIN_SOLUTION
+
+    hidden_tests (s);
+
+    // END_SOLUTION
     return s;
 }
 


### PR DESCRIPTION
Hidden unit tests are stored in tests/hidden.c. The sections of code in
tests/testsuite.c that require functions from hidden.c are removed when
preparing for distribution using the existing
BEGIN_SOLUTION/END_SOLUTION removal logic.

dist/rebuild-p*.sh need to be modified to not copy tests/testsuite.c
directly into the distribution directory.