### PR TITLE
Hide private test line numbers on error

### DIFF
--- a/ref/p0-intro/tests/Makefile
+++ b/ref/p0-intro/tests/Makefile
@@ -45,7 +45,7 @@ utest: $(EXE) $(TEST)
 	@echo "========================================"
 	@echo "             UNIT TESTS"
 	@./$(TEST) 2>/dev/null >$(UTESTOUT)
-	@cat $(UTESTOUT) | sed -n -e '/Checks/,$$p' | sed -e 's/^private.*:F://g'
+	@cat $(UTESTOUT) | sed -n -e '/Checks/,$$p' | sed -e 's/^private.*:[EF]://g'
 
 itest: $(EXE)
 	@echo "========================================"

--- a/ref/pT-blank/tests/Makefile
+++ b/ref/pT-blank/tests/Makefile
@@ -45,7 +45,7 @@ utest: $(EXE) $(TEST)
 	@echo "========================================"
 	@echo "             UNIT TESTS"
 	@./$(TEST) 2>/dev/null >$(UTESTOUT)
-	@cat $(UTESTOUT) | sed -n -e '/Checks/,$$p' | sed -e 's/^private.*:F://g'
+	@cat $(UTESTOUT) | sed -n -e '/Checks/,$$p' | sed -e 's/^private.*:[EF]://g'
 
 itest: $(EXE)
 	@echo "========================================"


### PR DESCRIPTION
If a unit test failed due to an error rather than an assertion failure,
the line number would appear in the unit test summary.